### PR TITLE
add clang support along with gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ sysconfdir  = ${prefix}/etc
 init_script = etc/init.d/gtp-guard.init
 conf_file   = etc/gtp-guard/gtp-guard.conf
 
-CC        = gcc
+CC        ?= gcc
 LDFLAGS   = -lpthread -lcrypt -ggdb -lm -lz -lresolv -lelf
 SUBDIRS   = lib src
 LIBBPF    = libbpf

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ git clone --recursive git@github.com:acassen/gtp-guard.git
 cd gtp-guard
 make -j $(nproc)
 ```
+
+gcc is the default compiled. Should you prefer the usage of clang, then use:
+```
+CC=clang make -j $(nproc)
+```

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -19,7 +19,7 @@
 # Copyright (C) 2023 Alexandre Cassen, <acassen@gmail.com>
 #
 
-CC	 = gcc
+CC	 ?= gcc
 INCLUDES = -I.
 CFLAGS	 = -g -O2 $(INCLUDES) -Wall -Wunused -Wstrict-prototypes
 #DEFS	 = -D_DEBUG_

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@
 # Copyright (C) 2023 Alexandre Cassen, <acassen@gmail.com>
 #
 
-CC	 = gcc
+CC	 ?= gcc
 INCLUDES = -Iinclude -I../lib -I../libbpf/src -I../libbpf/src/uapi
 CFLAGS	 = -g -O2 -ggdb $(INCLUDES) -Wall -Wunused -Wstrict-prototypes -D_GNU_SOURCE
 #DEFS	 = -D_DEBUG_


### PR DESCRIPTION
Since clang is pretty aggressive, it allows to detect some weird cases such as:
```
gtp_ppp.c:1994:14: warning: implicit conversion from 'int' to 'char' changes value from 129 to -127 [-Wconstant-conversion]
                opt[i++] = IPCP_OPT_PRIMDNS;
                         ~ ^~~~~~~~~~~~~~~~
include/gtp_ppp.h:65:26: note: expanded from macro 'IPCP_OPT_PRIMDNS'
#define IPCP_OPT_PRIMDNS        129     /* primary remote dns address */
                                ^~~
```

TODO: if this pull request is accepted, I will (1) try to fix the issues raised by clang and then (2) extend the compilation tests to run with both gcc and clang.