### PR TITLE
test compilation with both gcc and clang

### DIFF
--- a/.github/workflows/actions-compile.yml
+++ b/.github/workflows/actions-compile.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [ gcc, clang ]
     steps:
       - name: add missing packages
         uses: ConorMacBride/install-package@v1
@@ -20,6 +23,6 @@ jobs:
         with:
           submodules: true
       - name: make
-        run : make -j $(nproc)
+        run : CC=${{ matrix.compiler }} make -j $(nproc)
       - name: basic run
         run : bin/gtp-guard --version


### PR DESCRIPTION
Since clang can be quite agressive for some checks, let's try both compilations.

references:
  https://levelup.gitconnected.com/utilizing-github-actions-to-build-and-test-on-multiple-platforms-a7fe3aa6ce2a
  https://docs.github.com/en/actions/using-workflows/about-workflows#using-a-matrix