### PR TITLE
README: few notes to enable GTPu and GTPc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Define your own `gtp-guard.conf` settings in order to enable its vty over TCP.
 ```
 $ cat <<EOFCONF > /tmp/gtp-guard.conf
 !
+gtp-router demo
+  gtpc-tunnel-endpoint 0.0.0.0 port 2123
+  gtpu-tunnel-endpoint 0.0.0.0 port 2152
+!
 line vty
   no login
   listen 127.0.0.1 8888


### PR DESCRIPTION
set the listening ports

The number of listener is set at compilation time. Later on, it'll be changeable using listener-count argument:
  gtpc-tunnel-endpoint 0.0.0.0 port 2123 listener-count 1
  gtpu-tunnel-endpoint 0.0.0.0 port 2152 listener-count 1
currently, it is only valid for gtpc but note that write terminal will not restore this value.