### PR TITLE
Alternate file for /var/run/gtp-guard.pid / getenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Connection closed by foreign host.
 ```
 
 Then you can start sending your GTPc and GTPu workload to the UDP ports 2123 and 2152.
+
+## getenv settings
+
+  - `GTP_GUARD_PID_FILE` : set alternate pid file (default = /var/run/gtp-guard.pid)

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,8 @@ struct {
 	{LOG_LOCAL4}, {LOG_LOCAL5}, {LOG_LOCAL6}, {LOG_LOCAL7}
 };
 
+static char * __prog_pid_file = PROG_PID_FILE;
+
 /* Daemon stop sequence */
 static void
 stop_gtp(void)
@@ -63,7 +65,7 @@ stop_gtp(void)
 	memory_free_final("gtp-guard process");
 #endif
 	closelog();
-	pidfile_rm(PROG_PID_FILE);
+	pidfile_rm(__prog_pid_file);
 	exit(EXIT_SUCCESS);
 }
 
@@ -253,8 +255,10 @@ main(int argc, char **argv)
 	openlog(PROG, LOG_PID | (debug & 1) ? LOG_PERROR : 0, log_facility);
 	syslog(LOG_INFO, "Starting " VERSION_STRING "\n");
 
+	if (getenv("GTP_GUARD_PID_FILE"))
+		__prog_pid_file = getenv("GTP_GUARD_PID_FILE");
 	/* Check if ncsd is already running */
-	if (process_running(PROG_PID_FILE)) {
+	if (process_running(__prog_pid_file)) {
 		syslog(LOG_INFO, "daemon is already running");
 		goto end;
 	}
@@ -267,7 +271,7 @@ main(int argc, char **argv)
 		xdaemon(0, 0, 0);
 
 	/* write the pidfile */
-	if (!pidfile_write(PROG_PID_FILE, getpid()))
+	if (!pidfile_write(__prog_pid_file, getpid()))
 		goto end;
 
 	/* Increase maximum fd limit */


### PR DESCRIPTION
Run GTP_GUARD_PID_FILE=/tmp/gtp.pid bin/gtp-guard args... in order to to define an alternate file. It can be useful on Docker environment or others when /var/run shall not be used.

I will need it in order to run gtp-guard with some gtping tests using github's Actions.