### PR TITLE
gtp_route: fix eBPF load error

### DIFF
--- a/src/bpf/gtp_route.c
+++ b/src/bpf/gtp_route.c
@@ -69,7 +69,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 	__uint(max_entries, 10000000);
-	__type(key, struct ip_ppp_key);			/* hw + sessionid */
+	__type(key, struct ppp_key);			/* hw + sessionid */
 	__type(value, struct gtp_rt_rule);		/* GTP Encapsulation Rule */
 } ppp_ingress SEC(".maps");
 


### PR DESCRIPTION
fix for:
  [...]
  libbpf: map 'teid_ingress': found map_flags = 1.
  libbpf: map 'ppp_ingress': at sec_idx 6, offset 120.
  libbpf: map 'ppp_ingress': can't determine key size for type [30]: -22.
  ERROR: opening BPF object file failed

note: it was detected by testenv.sh (see the pull request !15)