### PR TITLE
eBPF: include its compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ conf_file   = etc/gtp-guard/gtp-guard.conf
 
 CC        ?= gcc
 LDFLAGS   = -lpthread -lcrypt -ggdb -lm -lz -lresolv -lelf
-SUBDIRS   = lib src
+SUBDIRS   = lib src src/bpf
 LIBBPF    = libbpf
 OBJDIR    = $(LIBBPF)/src
 


### PR DESCRIPTION
Till now, we add to compile the eBPF module independently of gtp-guard, what's about including its compilation too ?

TODO: if it is approve and merge, it means that we should update the github's workflow that was taking care of this standalone compilation too.