### PR TITLE
minor: ebpf modules are already compiled

### DIFF
--- a/.github/workflows/actions-compile.yml
+++ b/.github/workflows/actions-compile.yml
@@ -25,8 +25,6 @@ jobs:
           submodules: true
       - name: make gtp-guard
         run : CC=${{ matrix.compiler }} make -j $(nproc)
-      - name: make eBPF
-        run : cd src/bpf && make
       - name: basic run
         run : bin/gtp-guard --version
       - name: Upload gtp-guard artifacts


### PR DESCRIPTION
This action can be removed from the workflow since make all does the job since the commit a8b0df8288f