### PR TITLE
test gtp_mirror.bpf

### DIFF
--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -167,13 +167,8 @@ ip netns exec sandbox \
 ip netns exec sandbox \
   ip link set dev lo xdpgeneric off
 
-# XXX TODO: error missing sec prog
-# ip netns exec sandbox \
-#  ip link set dev lo xdpgeneric obj $bpfmirror verbose
-# ip netns exec sandbox \
-#  ip -d link show dev lo
-# ip netns exec sandbox \
-#  ip link set dev lo xdpgeneric off
+ip netns exec sandbox \
+  bpftool -d prog load $bpfmirror /sys/fs/bpf/mirror
 
 ip netns del sandbox
 


### PR DESCRIPTION
test using bpftool, example of check:
  https://github.com/vjardin/gtp-guard/actions/runs/7924514635/job/21636224232#step:4:382
the purpose is to have the validation from the kernel's verifier.
It is not a unit test using bpftool prog run:
```
  bpftool prog run PROG data_in FILE [data_out FILE [data_size_out L]] [ctx_in FILE [ctx_out FILE [ctx_size_out M]]] [repeat N]
```