### PR TITLE
Draft: xdp: checksum optimization

### DIFF
--- a/src/bpf/gtp_fwd.c
+++ b/src/bpf/gtp_fwd.c
@@ -208,9 +208,9 @@ gtpu_xlat_iph(struct iphdr *iph, __be32 daddr)
 	iph->saddr = iph->daddr;
 	iph->daddr = daddr;
 	--iph->ttl;
-	iph->check = 0;
-	ipv4_csum(iph, sizeof(struct iphdr), &csum);
-	iph->check = csum;
+	/* avoid doing ipv4_csum(iph, sizeof(struct iphdr), &csum); */
+	csum = iph->check + 0x100; /* RFC 1141: incremet checksum high byte */
+	iph->check = csum + (csum >> 16); /* add carry */
 }
 
 static __always_inline void

--- a/src/bpf/gtp_fwd.c
+++ b/src/bpf/gtp_fwd.c
@@ -202,7 +202,7 @@ gtpu_ipencap(struct parse_pkt *pkt, struct gtp_iptnl_rule *iptnl_rule)
 static __always_inline void
 gtpu_xlat_iph(struct iphdr *iph, __be32 daddr)
 {
-	__u32 csum = 0;
+	__u32 csum;
 
 	/* Phase 1 : rewrite IP header */
 	iph->saddr = iph->daddr;


### PR DESCRIPTION
Let's apply the optimization from the RFC1141 since we do not need to recompute the checksum for each ttl--

Warning: I am still trying to run a virtual lab environment, so this commit is untested.

I'd like to keep this pull request "opened" until it'll be fully tested. Currently, it is just based on proof reading.