### PR TITLE
gcc noclang take2

### DIFF
--- a/src/bpf/Makefile
+++ b/src/bpf/Makefile
@@ -27,6 +27,15 @@ BIN = ../../bin
 #  make samples/bpf/ LLC=~/git/llvm/build/bin/llc CLANG=~/git/llvm/build/bin/clang
 LLC ?= llc
 CLANG ?= clang
+
+# gcc does not support Assembly IR, so there is no such LLC wich gcc
+ifeq ($(CLANG), gcc)
+  LLC = gcc
+endif
+ifeq ($(LLC), gcc)
+  CLANG = gcc
+endif
+
 CFLAGS := -g -O2 -Wall -Werror
 
 # Include for BPF are pointing to libbpf
@@ -47,6 +56,19 @@ clean:
 # asm/sysreg.h - inline assembly used by it is incompatible with llvm.
 # But, there is no easy way to fix it, so just exclude it since it is
 # useless for BPF samples.
+ifeq ($(LLC), gcc)
+$(TARGETS): %.bpf: %.c
+	@echo "  GCC-bpf" $@
+	@$(CLANG) $(CFLAGS) -S $(NOSTDINC_FLAGS) $(LINUXINCLUDE) \
+	    -D__KERNEL__ -D__ASM_SYSREG_H \
+	    -D__BPF_TRACING__ \
+	    -Wall \
+	    -Wno-unused-value -Wno-pointer-sign \
+	    -D__TARGET_ARCH_$(ARCH) \
+	    -Wno-tautological-compare \
+	    -Wno-address-of-packed-member \
+	    -O2 -emit-llvm -g -c $< -o $(BIN)/$@
+else
 $(TARGETS): %.bpf: %.c
 	@echo "  CLANG-bpf" $@
 	@$(CLANG) $(CFLAGS) -S $(NOSTDINC_FLAGS) $(LINUXINCLUDE) \
@@ -62,3 +84,4 @@ $(TARGETS): %.bpf: %.c
 	    -Wno-address-of-packed-member \
 	    -O2 -emit-llvm -g -c $< -o ${@:.bpf=.ll}
 	@$(LLC) -march=bpf -filetype=obj -o $(BIN)/$@ ${@:.bpf=.ll}
+endif

--- a/src/bpf/Makefile
+++ b/src/bpf/Makefile
@@ -33,8 +33,8 @@ CFLAGS := -g -O2 -Wall -Werror
 LIBBPF = ../../libbpf
 LINUXINCLUDE := -I$(LIBBPF)/src
 
-all: dependencies $(TARGETS)
-.PHONY: dependencies clean $(CLANG) $(LLC)
+all: $(TARGETS)
+.PHONY: clean $(CLANG) $(LLC)
 
 clean:
 	@find . -type f			\
@@ -43,22 +43,6 @@ clean:
 		-o -name '*.bc' \)	\
 		-exec rm -vf '{}'	\;
 	@for i in $(TARGETS); do rm -vf $(BIN)/"$$i"; done
-
-dependencies: verify_cmds verify_target_bpf
-verify_cmds: $(CLANG) $(LLC)
-	@for TOOL in $^ ; do \
-		if ! (which -- "$${TOOL}" > /dev/null 2>&1); then \
-			echo "*** ERROR: Cannot find LLVM tool $${TOOL}" ;\
-			exit 1; \
-		else true; fi; \
-	done
-verify_target_bpf: verify_cmds
-	@if ! (${LLC} -march=bpf -mattr=help > /dev/null 2>&1); then \
-		echo "*** ERROR: LLVM (${LLC}) does not support 'bpf' target" ;\
-		echo "   NOTICE: LLVM version >= 3.7.1 required" ;\
-		exit 2; \
-	else true; fi
-
 
 # asm/sysreg.h - inline assembly used by it is incompatible with llvm.
 # But, there is no easy way to fix it, so just exclude it since it is


### PR DESCRIPTION
Assuming the pull request https://github.com/acassen/gtp-guard/pull/27 is merged, then this pull request enables the usage of gcc for the bpf modules.

This pull request is currently a placeholder as a WIP.