### PR TITLE
Verbose bpf + allow define-able prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ VERSION := $(shell cat VERSION)
 TARBALL = $(EXEC)-$(VERSION).tar.xz
 TARFILES = AUTHOR VERSION LICENSE README.md bin src lib Makefile libbpf
 
-prefix = /usr/local
-exec_prefix = ${prefix}
-sbindir     = ${exec_prefix}/sbin
-sysconfdir  = ${prefix}/etc
+prefix ?= /usr/local
+exec_prefix ?= ${prefix}
+sbindir     ?= ${exec_prefix}/sbin
+sysconfdir  ?= ${prefix}/etc
 init_script = etc/init.d/gtp-guard.init
 conf_file   = etc/gtp-guard/gtp-guard.conf
 
@@ -66,7 +66,7 @@ uninstall:
 	rm -f $(sbindir)/$(EXEC)
 
 install:
-	install -d $(prefix)
+	install -d $(sbindir)
 	install -m 700 $(BIN)/$(EXEC) $(sbindir)/$(EXEC)-$(VERSION)
 	ln -sf $(sbindir)/$(EXEC)-$(VERSION) $(sbindir)/$(EXEC)
 

--- a/src/bpf/Makefile
+++ b/src/bpf/Makefile
@@ -47,6 +47,7 @@ clean:
 dependencies: verify_cmds verify_target_bpf
 verify_cmds: $(CLANG) $(LLC)
 	@for TOOL in $^ ; do \
+		which $${TOOL} ;\
 		if ! (which -- "$${TOOL}" > /dev/null 2>&1); then \
 			echo "*** ERROR: Cannot find LLVM tool $${TOOL}" ;\
 			exit 1; \


### PR DESCRIPTION
Add support to any target folder, the main purpose is to support packages such as Buildroot ones.

Let's be a bit verbose on clang and llc that are selected since it can become complex to debug.