### PR TITLE
README: all bpf are into bin/

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ sudo ./testenv.sh \
   -u path/dev/gtpu-guard/test/gtpu-ping.py \
   -g path/dev/gtp-guard/bin/gtp-guard \
   -c /tmp/gtp-guard.conf \
-  -f path/dev/gtp-guard/src/bpf/gtp_fwd.bpf \
-  -r path/dev/gtp-guard/src/bpf/gtp_route.bpf \
-  -m path/dev/gtp-guard/src/bpf/gtp_mirror.bpf \
+  -f path/dev/gtp-guard/bin/gtp_fwd.bpf \
+  -r path/dev/gtp-guard/bin/gtp_route.bpf \
+  -m path/dev/gtp-guard/bin/gtp_mirror.bpf \
   -k no
 ```
 


### PR DESCRIPTION
Cosmetic update about the target bpf files which are into the bin/ folder instead of src/bpf.