### PR TITLE
cosmetic - no signal handler for SIGKILL

### DIFF
--- a/lib/signals.c
+++ b/lib/signals.c
@@ -199,7 +199,7 @@ signal_set(int signo, void (*func) (void *, int), void *v)
 	}
 
 	if (sigaction(signo, &sig, NULL))
-		log_message(LOG_INFO, "sigaction failed for signalfd");
+		log_message(LOG_INFO, "sigaction failed for signo %d", signo);
 
 	if (!func)
 		sigmask_func(SIG_UNBLOCK, &sset, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,6 @@ signal_init(void)
 	signal_set(SIGHUP, sigend, NULL);
 	signal_set(SIGINT, sigend, NULL);
 	signal_set(SIGTERM, sigend, NULL);
-	signal_set(SIGKILL, sigend, NULL);
 	signal_noignore_sigchld();
 	signal_ignore(SIGPIPE);
 }


### PR DESCRIPTION
Remove the runtime logs:
```
  gtp-guard[264013]: sigaction failed for signalfd
```

Meanwhile the log is updated in order to get the signal id:
```
  gtp-guard[264472]: sigaction failed for signo 9
```