### PR TITLE
dlock: remove unused refcnt

### DIFF
--- a/src/gtp_conn.c
+++ b/src/gtp_conn.c
@@ -39,7 +39,7 @@ extern thread_master_t *master;
 /* Local data */
 struct hlist_head *gtp_conn_tab;
 static int gtp_conn_tab_cnt = 0;
-dlock_mutex_t *__gtp_conn_lock_array;
+pthread_mutex_t *__gtp_conn_lock_array;
 
 
 /*
@@ -60,15 +60,15 @@ gtp_conn_unlock_id(uint64_t id)
 int
 gtp_conn_lock_init(void)
 {
-        __gtp_conn_lock_array = dlock_init();
-        return 0;
+	__gtp_conn_lock_array = dlock_init();
+	return 0;
 }
 
 int
 gtp_conn_lock_destroy(void)
 {
 	FREE(__gtp_conn_lock_array);
-        return 0;
+	return 0;
 }
 
 
@@ -78,18 +78,18 @@ gtp_conn_lock_destroy(void)
 int
 gtp_conn_get(gtp_conn_t *c)
 {
-        if (!c)
-                return 0;
-        __sync_add_and_fetch(&c->refcnt, 1);
+	if (!c)
+		return 0;
+	__sync_add_and_fetch(&c->refcnt, 1);
 	return 0;
 }
 
 int
 gtp_conn_put(gtp_conn_t *c)
 {
-        if (!c)
-                return 0;
-        __sync_sub_and_fetch(&c->refcnt, 1);
+	if (!c)
+		return 0;
+	__sync_sub_and_fetch(&c->refcnt, 1);
 	return 0;
 }
 

--- a/src/include/gtp_htab.h
+++ b/src/include/gtp_htab.h
@@ -27,22 +27,16 @@
 #define DLOCK_HASHTAB_SIZE    (1 << DLOCK_HASHTAB_BITS)
 #define DLOCK_HASHTAB_MASK    (DLOCK_HASHTAB_SIZE - 1)
 
-typedef struct _dlock_mutex {
-	pthread_mutex_t		mutex;
-	uint32_t		refcnt;
-} dlock_mutex_t;
-
 /* htab */
 typedef struct _gtp_htab {
 	struct hlist_head	*htab;
-	dlock_mutex_t		*dlock;
+	pthread_mutex_t		*dlock;
 } gtp_htab_t;
 
 /* Prototypes */
-extern int dlock_lock_id(dlock_mutex_t *, uint32_t, uint32_t);
-extern int dlock_unlock_id(dlock_mutex_t *, uint32_t, uint32_t);
-extern dlock_mutex_t *dlock_init(void);
-extern int dlock_destroy(dlock_mutex_t *);
+extern int dlock_lock_id(pthread_mutex_t *, uint32_t, uint32_t);
+extern int dlock_unlock_id(pthread_mutex_t *, uint32_t, uint32_t);
+extern pthread_mutex_t *dlock_init(void);
 extern void gtp_htab_init(gtp_htab_t *, size_t);
 extern void gtp_htab_destroy(gtp_htab_t *);
 


### PR DESCRIPTION
refcnt is not needed in dlock_mutex struct, because lock is always kept hold while this refcnt is updated.

remove it and simplify code.