### PR TITLE
GTPv1: fix update of the serving node in delete PDP context request handler

### DIFF
--- a/src/gtp_switch_hdl_v1.c
+++ b/src/gtp_switch_hdl_v1.c
@@ -701,6 +701,10 @@ gtp1_delete_pdp_request_hdl(gtp_server_worker_t *w, struct sockaddr_storage *add
 	/* Recovery xlat */
 	gtp1_session_xlat_recovery(w);
 
+	/* Update addr tunnel endpoint */
+	gtp_teid_update_sgw(teid, addr);
+	gtp_teid_update_sgw(teid->peer_teid, addr);
+
 	/* Update SQN */
 	gtp_sqn_update(w, teid);
 	gtp_vsqn_alloc(w, teid, false);


### PR DESCRIPTION
During delete PDP context request handling the serving node must be updated to forward the delete PDP context request to the PGW. Without this fix the message is forwarded to the last serving node which contacted GTP-Guard.