### PR TITLE
gtp_bpf_prog: add template system

### DIFF
--- a/src/carrier-grade-nat/cgn.c
+++ b/src/carrier-grade-nat/cgn.c
@@ -34,6 +34,7 @@
 #include "vty.h"
 #include "command.h"
 #include "gtp_data.h"
+#include "gtp_bpf_prog.h"
 #include "cgn.h"
 
 /* Extern data */
@@ -44,6 +45,37 @@ extern thread_master_t *master;
 /*
  *	CGN utilities
  */
+
+
+/*
+ * BPF stuff
+ */
+
+static int
+cgn_bpf_opened(gtp_bpf_prog_t *p, struct bpf_object *obj)
+{
+	return 0;
+}
+
+static int
+cgn_bpf_loaded(gtp_bpf_prog_t *p, struct bpf_object *obj)
+{
+	return 0;
+}
+
+static gtp_bpf_prog_tpl_t gtp_bpf_tpl_fwd = {
+	.name = "cgn",
+	.def_path = "/etc/gtp-guard/cgn.bpf",
+	.opened = cgn_bpf_opened,
+	.loaded = cgn_bpf_loaded,
+};
+
+static void __attribute__((constructor))
+gtp_bpf_fwd_init(void)
+{
+	gtp_bpf_prog_tpl_register(&gtp_bpf_tpl_fwd);
+}
+
 
 
 /* compact addr/netmask from cgn_addr array.

--- a/src/gtp_bpf_fwd.c
+++ b/src/gtp_bpf_fwd.c
@@ -30,8 +30,8 @@ extern data_t *daemon_data;
 /*
  *	XDP FWD BPF related
  */
-int
-gtp_bpf_fwd_load_maps(gtp_bpf_prog_t *p)
+static int
+gtp_bpf_fwd_load_maps(gtp_bpf_prog_t *p, struct bpf_object *bpf_obj)
 {
 	/* TODO: migrate to bpf-program paradigm */
 	return -1;
@@ -364,4 +364,17 @@ gtp_bpf_fwd_iptnl_vty(vty_t *vty)
 		return -1;
 
 	return gtp_bpf_iptnl_vty(vty, bpf_opts->bpf_maps[XDP_FWD_MAP_IPTNL].map);
+}
+
+
+static gtp_bpf_prog_tpl_t gtp_bpf_tpl_fwd = {
+	.name = "gtp-forward",
+	.def_path = "/etc/gtp-guard/gtp-fwd.bpf",
+	.loaded = gtp_bpf_fwd_load_maps,
+};
+
+static void __attribute__((constructor))
+gtp_bpf_fwd_init(void)
+{
+	gtp_bpf_prog_tpl_register(&gtp_bpf_tpl_fwd);
 }

--- a/src/gtp_bpf_rt.c
+++ b/src/gtp_bpf_rt.c
@@ -30,50 +30,45 @@ extern data_t *daemon_data;
 /*
  *	XDP RT BPF related
  */
-int
-gtp_bpf_rt_load_maps(gtp_bpf_prog_t *p)
+static int
+gtp_bpf_rt_load_maps(gtp_bpf_prog_t *p, struct bpf_object *bpf_obj)
 {
 	struct bpf_map *map;
 
 	/* MAP ref for faster access */
 	p->bpf_maps = MALLOC(sizeof(gtp_bpf_maps_t) * XDP_RT_MAP_CNT);
-	map = gtp_bpf_load_map(p->bpf_obj, "teid_ingress");
+	map = gtp_bpf_load_map(bpf_obj, "teid_ingress");
 	if (!map)
 		return -1;
 	p->bpf_maps[XDP_RT_MAP_TEID_INGRESS].map = map;
 
-	map = gtp_bpf_load_map(p->bpf_obj, "teid_egress");
+	map = gtp_bpf_load_map(bpf_obj, "teid_egress");
 	if (!map)
 		return -1;
 	p->bpf_maps[XDP_RT_MAP_TEID_EGRESS].map = map;
 
-	map = gtp_bpf_load_map(p->bpf_obj, "ppp_ingress");
+	map = gtp_bpf_load_map(bpf_obj, "ppp_ingress");
 	if (!map)
 		return -1;
 	p->bpf_maps[XDP_RT_MAP_PPP_INGRESS].map = map;
 
-	map = gtp_bpf_load_map(p->bpf_obj, "iptnl_info");
+	map = gtp_bpf_load_map(bpf_obj, "iptnl_info");
 	if (!map)
 		return -1;
 	p->bpf_maps[XDP_RT_MAP_IPTNL].map = map;
 
-	map = gtp_bpf_load_map(p->bpf_obj, "if_lladdr");
+	map = gtp_bpf_load_map(bpf_obj, "if_lladdr");
 	if (!map)
 		return -1;
 	p->bpf_maps[XDP_RT_MAP_IF_LLADDR].map = map;
 
-	map = gtp_bpf_load_map(p->bpf_obj, "if_stats");
+	map = gtp_bpf_load_map(bpf_obj, "if_stats");
 	if (!map)
 		return -1;
 	p->bpf_maps[XDP_RT_MAP_IF_STATS].map = map;
 	return 0;
 }
 
-void
-gtp_bpf_rt_unload_maps(gtp_bpf_prog_t *p)
-{
-	FREE_PTR(p->bpf_maps);
-}
 
 /*
  *	Statistics
@@ -671,4 +666,17 @@ gtp_bpf_rt_lladdr_vty(vty_t *vty)
 
 	free(ll);
 	return 0;
+}
+
+
+static gtp_bpf_prog_tpl_t gtp_bpf_tpl_rt = {
+	.name = "gtp-route",
+	.def_path = "/etc/gtp-guard/gtp-route.bpf",
+	.loaded = gtp_bpf_rt_load_maps,
+};
+
+static void __attribute__((constructor))
+gtp_bpf_rt_init(void)
+{
+	gtp_bpf_prog_tpl_register(&gtp_bpf_tpl_rt);
 }

--- a/src/include/gtp_bpf_fwd.h
+++ b/src/include/gtp_bpf_fwd.h
@@ -44,7 +44,6 @@ struct gtp_teid_rule {
 } __attribute__ ((__aligned__(8)));
 
 /* Prototypes */
-extern int gtp_bpf_fwd_load_maps(gtp_bpf_prog_t *);
 extern int gtp_bpf_fwd_load(gtp_bpf_opts_t *);
 extern void gtp_bpf_fwd_unload(gtp_bpf_opts_t *);
 extern int gtp_bpf_fwd_teid_action(int, gtp_teid_t *);

--- a/src/include/gtp_bpf_prog.h
+++ b/src/include/gtp_bpf_prog.h
@@ -16,14 +16,27 @@
  *              either version 3.0 of the License, or (at your option) any later
  *              version.
  *
- * Copyright (C) 2023-2024 Alexandre Cassen, <acassen@gmail.com>
+ * Copyright (C) 2023-2025 Alexandre Cassen, <acassen@gmail.com>
  */
 #pragma once
 
+typedef struct _gtp_bpf_prog gtp_bpf_prog_t;
+
+/* BPF prog template */
+typedef struct _gtp_bpf_prog_tpl {
+	char			name[GTP_STR_MAX_LEN];
+	char			def_path[GTP_PATH_MAX_LEN];
+	char			def_progname[GTP_STR_MAX_LEN];
+
+	int (*opened)(gtp_bpf_prog_t *, struct bpf_object *);
+	int (*loaded)(gtp_bpf_prog_t *, struct bpf_object *);
+
+	list_head_t		next;
+} gtp_bpf_prog_tpl_t;
+
+
 /* Flags */
 enum gtp_bpf_prog_flags {
-	GTP_BPF_PROG_FL_RT_BIT,
-	GTP_BPF_PROG_FL_FWD_BIT,
 	GTP_BPF_PROG_FL_SHUTDOWN_BIT,
 };
 
@@ -36,12 +49,14 @@ typedef struct _gtp_bpf_prog {
 	struct bpf_object	*bpf_obj;
 	struct bpf_program	*bpf_prog;
 	gtp_bpf_maps_t		*bpf_maps;
+	const gtp_bpf_prog_tpl_t *tpl;
 
 	list_head_t		next;
 
 	int			refcnt;
 	unsigned long		flags;
 } gtp_bpf_prog_t;
+
 
 /* Prototypes */
 extern struct bpf_link *gtp_bpf_prog_attach(gtp_bpf_prog_t *, int);
@@ -54,3 +69,5 @@ extern gtp_bpf_prog_t *gtp_bpf_prog_get(const char *);
 extern int gtp_bpf_prog_put(gtp_bpf_prog_t *);
 extern gtp_bpf_prog_t *gtp_bpf_prog_alloc(const char *);
 extern int gtp_bpf_progs_destroy(void);
+void gtp_bpf_prog_tpl_register(gtp_bpf_prog_tpl_t *tpl);
+const gtp_bpf_prog_tpl_t *gtp_bpf_prog_tpl_get(const char *name);

--- a/src/include/gtp_bpf_rt.h
+++ b/src/include/gtp_bpf_rt.h
@@ -91,8 +91,6 @@ struct metrics {
 
 /* Prototypes */
 extern const char *gtp_rt_stats_metrics_str(int);
-extern int gtp_bpf_rt_load_maps(gtp_bpf_prog_t *);
-extern void gtp_bpf_rt_unload_maps(gtp_bpf_prog_t *);
 extern int gtp_bpf_rt_metrics_init(gtp_bpf_prog_t *, int, int);
 extern int gtp_bpf_rt_metrics_dump(gtp_bpf_prog_t *,
 				   int (*dump) (void *, __u8, __u8, struct metrics *),


### PR DESCRIPTION
Create a bpf program template system, so bpf program modules (gtp-fwd, cgn, ...) can register themselves with their name and useful callbacks.

Add 2 callbacks:
  - loaded: after bpf_object__open(), allow modify map attribute or set consts
  - opened: after bpf_object__load(), can fill maps.

Update bpf_prog_vty to set template on 'mode-xxx' command.

Set gtp_bpf_*_load_maps function to opened callback.