### PR TITLE
gtp_bpf_prog: update

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -46,6 +46,7 @@ typedef enum _node_type {
 	CFG_LOG_NODE,					/* Configure the logging */
 
 	PDN_NODE,					/* PDN daemon commands. */
+	CGN_NODE,					/* Carrier Grade NAT */
 	BPF_PROG_NODE,					/* BPF prog commands. */
 	INTERFACE_NODE,					/* Interface commands. */
 	PPPOE_NODE,					/* PPPoE commands. */
@@ -55,7 +56,6 @@ typedef enum _node_type {
 	CDR_NODE,					/* CDR commands. */
 	GTP_PROXY_NODE,					/* GTP Proxy commands. */
 	GTP_ROUTER_NODE,				/* GTP Router commands. */
-	CGN_NODE,					/* Carrier Grade NAT */
 
 	VTY_NODE,					/* Vty node. */
 } node_type_t;

--- a/src/bpf/gtp_fwd.c
+++ b/src/bpf/gtp_fwd.c
@@ -744,4 +744,5 @@ int xdp_fwd(struct xdp_md *ctx)
 	return gtpu_traffic_selector(&pkt);
 }
 
+const char _mode[] = "gtp_fwd";
 char _license[] SEC("license") = "GPL";

--- a/src/bpf/gtp_route.c
+++ b/src/bpf/gtp_route.c
@@ -958,4 +958,5 @@ int xdp_route(struct xdp_md *ctx)
 	return gtp_route_traffic_selector(&pkt);
 }
 
+const char _mode[] = "gtp_route";
 char _license[] SEC("license") = "GPL";

--- a/src/carrier-grade-nat/cgn.c
+++ b/src/carrier-grade-nat/cgn.c
@@ -64,9 +64,8 @@ cgn_bpf_loaded(gtp_bpf_prog_t *p, struct bpf_object *obj)
 }
 
 static gtp_bpf_prog_tpl_t gtp_bpf_tpl_cgn = {
-	.mode = CGN,
+	.mode = BPF_PROG_MODE_CGN,
 	.description = "cgn",
-	.def_path = "/etc/gtp-guard/cgn.bpf",
 	.opened = cgn_bpf_opened,
 	.loaded = cgn_bpf_loaded,
 };

--- a/src/gtp_bpf_fwd.c
+++ b/src/gtp_bpf_fwd.c
@@ -291,8 +291,6 @@ gtp_bpf_fwd_vty(gtp_bpf_prog_t *p, void *arg)
 {
 	vty_t *vty = arg;
 
-	if (!p->tpl || p->tpl->mode != GTP_FORWARD)
-		return -1;
 	vty_out(vty, "bpf-program '%s'%s", p->name, VTY_NEWLINE);
 
 	vty_out(vty, "+------------+------------+------------------+-----------+--------------+---------------------+%s"
@@ -324,7 +322,7 @@ gtp_bpf_fwd_teid_bytes(gtp_teid_t *t, uint64_t *bytes)
 int
 gtp_bpf_fwd_iptnl_action(int action, gtp_iptnl_t *t, gtp_bpf_prog_t *p)
 {
-	if (!p || !p->tpl || p->tpl->mode != GTP_FORWARD)
+	if (!p || !p->tpl || p->tpl->mode != BPF_PROG_MODE_GTP_FORWARD)
 		return -1;
 
 	return gtp_bpf_iptnl_action(action, t, p->bpf_maps[XDP_FWD_MAP_IPTNL].map);
@@ -335,8 +333,6 @@ gtp_bpf_fwd_iptnl_vty(gtp_bpf_prog_t *p, void *arg)
 {
 	vty_t *vty = arg;
 
-	if (!p->tpl || p->tpl->mode != GTP_FORWARD)
-		return -1;
 	vty_out(vty, "bpf-program '%s'%s", p->name, VTY_NEWLINE);
 
 	return gtp_bpf_iptnl_vty(vty, p->bpf_maps[XDP_FWD_MAP_IPTNL].map);
@@ -344,9 +340,8 @@ gtp_bpf_fwd_iptnl_vty(gtp_bpf_prog_t *p, void *arg)
 
 
 static gtp_bpf_prog_tpl_t gtp_bpf_tpl_fwd = {
-	.mode = GTP_FORWARD,
+	.mode = BPF_PROG_MODE_GTP_FORWARD,
 	.description = "gtp-forward",
-	.def_path = "/etc/gtp-guard/gtp-fwd.bpf",
 	.loaded = gtp_bpf_fwd_load_maps,
 };
 

--- a/src/gtp_interface_metrics.c
+++ b/src/gtp_interface_metrics.c
@@ -43,7 +43,7 @@ gtp_interface_nl_rx_dump(gtp_interface_t *iface, FILE *fp,
 			  , var, iface->description, s->rx_bytes);
 		return 0;
 	}
-	
+
 	fprintf(fp, "%s{interface=\"%s\"} %lld\n"
 		  , var, iface->description, s->rx_packets);
 	fprintf(fp, "%s{interface=\"%s\",type=\"%s\"} %lld\n"
@@ -245,7 +245,7 @@ gtp_interface_metrics_var_dump(gtp_interface_t *iface, void *arg,
 	__u16 inuse = type << 8;
 	FILE *fp = arg;
 
-	if (!p || !p->tpl || p->tpl->mode != GTP_ROUTE)
+	if (!p || !p->tpl || p->tpl->mode != BPF_PROG_MODE_GTP_ROUTE)
 		return -1;
 
 	gtp_interface_metric_inuse(iface, &inuse);

--- a/src/gtp_vty.c
+++ b/src/gtp_vty.c
@@ -29,10 +29,10 @@ extern thread_master_t *master;
 
 static int pdn_config_write(vty_t *vty);
 cmd_node_t pdn_node = {
-        .node = PDN_NODE,
-        .parent_node = CONFIG_NODE,
-        .prompt = "%s(pdn)# ",
-        .config_write = pdn_config_write,
+	.node = PDN_NODE,
+	.parent_node = CONFIG_NODE,
+	.prompt = "%s(pdn)# ",
+	.config_write = pdn_config_write,
 };
 
 
@@ -54,14 +54,14 @@ DEFUN(pdn_realm,
       "Set Global PDN Realm\n"
       "name\n")
 {
-        if (argc < 1) {
-                vty_out(vty, "%% missing arguments%s", VTY_NEWLINE);
-                return CMD_WARNING;
-        }
+	if (argc < 1) {
+		vty_out(vty, "%% missing arguments%s", VTY_NEWLINE);
+		return CMD_WARNING;
+	}
 
 	strncpy(daemon_data->realm, argv[0], GTP_STR_MAX_LEN-1);
 
-        return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
 DEFUN(pdn_nameserver,
@@ -74,10 +74,10 @@ DEFUN(pdn_nameserver,
 	struct sockaddr_storage *addr = &daemon_data->nameserver;
 	int ret;
 
-        if (argc < 1) {
-                vty_out(vty, "%% missing arguments%s", VTY_NEWLINE);
-                return CMD_WARNING;
-        }
+	if (argc < 1) {
+		vty_out(vty, "%% missing arguments%s", VTY_NEWLINE);
+		return CMD_WARNING;
+	}
 
 	ret = inet_stosockaddr(argv[0], 53, addr);
 	if (ret < 0) {
@@ -88,7 +88,7 @@ DEFUN(pdn_nameserver,
 
 	gtp_resolv_init();
 
-        return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
 DEFUN(pdn_xdp_mirror,
@@ -131,16 +131,16 @@ DEFUN(no_pdn_xdp_mirror,
 		return CMD_WARNING;
 	}
 
-        gtp_bpf_mirror_unload(opts);
+	gtp_bpf_mirror_unload(opts);
 
-        /* Reset data */
+	/* Reset data */
 	memset(opts, 0, sizeof(gtp_bpf_opts_t));
 
-        vty_out(vty, "Success unloading eBPF program:%s%s"
-                   , opts->filename
-                   , VTY_NEWLINE);
+	vty_out(vty, "Success unloading eBPF program:%s%s"
+		   , opts->filename
+		   , VTY_NEWLINE);
 	__clear_bit(GTP_FL_MIRROR_LOADED_BIT, &daemon_data->flags);
-        return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
 static int
@@ -287,28 +287,28 @@ DEFUN(restart_counter_file,
       "GTP-C Local restart counter file\n"
       "path to restart counter file\n")
 {
-        int ret;
+	int ret;
 
-        if (argc < 1) {
-                vty_out(vty, "%% missing arguments%s", VTY_NEWLINE);
-                return CMD_WARNING;
-        }
+	if (argc < 1) {
+		vty_out(vty, "%% missing arguments%s", VTY_NEWLINE);
+		return CMD_WARNING;
+	}
 
 	strncpy(daemon_data->restart_counter_filename, argv[0], GTP_STR_MAX_LEN-1);
 
-        ret = gtp_disk_read_restart_counter();
-        if (ret < 0) {
-                daemon_data->restart_counter = 1;
-        } else {
+	ret = gtp_disk_read_restart_counter();
+	if (ret < 0) {
+		daemon_data->restart_counter = 1;
+	} else {
 		daemon_data->restart_counter = ret + 1;
-        }
-        gtp_disk_write_restart_counter();
+	}
+	gtp_disk_write_restart_counter();
 
-        vty_out(vty, "Success loading restart_counter:%d%s"
-                   , daemon_data->restart_counter
-                   , VTY_NEWLINE);
+	vty_out(vty, "Success loading restart_counter:%d%s"
+		   , daemon_data->restart_counter
+		   , VTY_NEWLINE);
 	__set_bit(GTP_FL_RESTART_COUNTER_LOADED_BIT, &daemon_data->flags);
-        return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
 static int
@@ -395,7 +395,7 @@ DEFUN(show_xdp_forwarding,
       SHOW_STR
       "XDP GTP Fowarding Dataplane ruleset\n")
 {
-	gtp_bpf_prog_foreach_prog(gtp_bpf_fwd_vty, vty);
+	gtp_bpf_prog_foreach_prog(gtp_bpf_fwd_vty, vty, BPF_PROG_MODE_GTP_FORWARD);
 	return CMD_SUCCESS;
 }
 
@@ -405,7 +405,7 @@ DEFUN(show_xdp_forwarding_iptnl,
       SHOW_STR
       "GTP XDP Forwarding IPIP Tunnel ruleset\n")
 {
-	gtp_bpf_prog_foreach_prog(gtp_bpf_fwd_iptnl_vty, vty);
+	gtp_bpf_prog_foreach_prog(gtp_bpf_fwd_iptnl_vty, vty, BPF_PROG_MODE_GTP_FORWARD);
 	return CMD_SUCCESS;
 }
 
@@ -415,7 +415,7 @@ DEFUN(show_xdp_routing,
       SHOW_STR
       "GTP XDP Routing Dataplane ruleset\n")
 {
-	gtp_bpf_prog_foreach_prog(gtp_bpf_rt_vty, vty);
+	gtp_bpf_prog_foreach_prog(gtp_bpf_rt_vty, vty, BPF_PROG_MODE_GTP_ROUTE);
 	return CMD_SUCCESS;
 }
 
@@ -425,7 +425,7 @@ DEFUN(show_xdp_routing_iptnl,
       SHOW_STR
       "GTP XDP Routing IPIP Tunnel ruleset\n")
 {
-	gtp_bpf_prog_foreach_prog(gtp_bpf_rt_iptnl_vty, vty);
+	gtp_bpf_prog_foreach_prog(gtp_bpf_rt_iptnl_vty, vty, BPF_PROG_MODE_GTP_ROUTE);
 	return CMD_SUCCESS;
 }
 
@@ -435,7 +435,7 @@ DEFUN(show_xdp_routing_lladdr,
       SHOW_STR
       "GTP XDP Routing link-layer Address\n")
 {
-	gtp_bpf_prog_foreach_prog(gtp_bpf_rt_lladdr_vty, vty);
+	gtp_bpf_prog_foreach_prog(gtp_bpf_rt_lladdr_vty, vty, BPF_PROG_MODE_GTP_ROUTE);
 	return CMD_SUCCESS;
 }
 

--- a/src/include/gtp_interface.h
+++ b/src/include/gtp_interface.h
@@ -27,6 +27,8 @@ enum gtp_interface_flags {
 	GTP_INTERFACE_FL_METRICS_IPIP_BIT,
 	GTP_INTERFACE_FL_METRICS_LINK_BIT,
 	GTP_INTERFACE_FL_DIRECT_TX_GW_BIT,
+	GTP_INTERFACE_FL_CGNAT_NET_IN_BIT,
+	GTP_INTERFACE_FL_CGNAT_NET_OUT_BIT,
 	GTP_INTERFACE_FL_SHUTDOWN_BIT,
 };
 
@@ -38,6 +40,7 @@ typedef struct _gtp_interface {
 	uint16_t		vlan_id;
 	ip_address_t		direct_tx_gw;
 	uint8_t			direct_tx_hw_addr[ETH_ALEN];
+	char			cgn_name[GTP_STR_MAX_LEN];
 	int			ifindex;
 	char			description[GTP_STR_MAX_LEN];
 	gtp_bpf_prog_t		*bpf_prog;


### PR DESCRIPTION
Remove vty's bpf-program mode-*. Set mode inside bfp program in variable "_mode", like _license.

Split bpf_prog_load() into bpf_prog_open() and bpf_prog_load(). It is necessary to open bpf prog to get access to "_mode", when program loading is deferred (see next item).

Add 'load_on_attach' option on bpf prog template: defer bpf loading, opened() and loaded() template callbacks, until all configuration blocks are read.

When set, bpf program is only opened, not loaded, on bpf-program no shut. It can be explicitely loaded later, or implicitely when attaching bpf program to interface.

By default, this option is unset and behave like previously: bpf program is loaded on bpf-program no shut.

Add vty command 'carrier-grade-nat' to enable cgn per interface.

Update vty node order to have carrier-grade-nat block before interfaces.